### PR TITLE
Proplist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,23 @@ const MyRecord = RecordWithConstructor<IMyRecordInput, IMyRecord>({
 const myInstance = MyRecord({b: '1970-01-01'});
 // myInstance.b is now a Moment object
 ```
+
+### Proplist
+
+A proplist is an array of 2-tuples of shape `[string, T]`, often used to represent simple ordered dictionary types and cases where mutiple keys may exist for the same item.  They are easily converted to Dicts and back again.
+
+```typescript
+const myProplist: Proplist<number> = [['a', 1], ['b', 2], ['b', 3]];
+
+const myDict = proplistToDict(myProplist);
+// myDict == {
+//   a: 1,
+//   b: 2
+// }
+
+const myOtherProplist = dictToProplist({a: 1, b: 2});
+// myOtherProplist == [
+//   ['a', 1],
+//   ['b', 2],
+// ];
+// // Order is not guaranteed as Dict is unordered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4150,7 +4150,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,6 @@
+export interface ObjectKeys {
+  [key: string]: any;
+}
+
+export type Dict<T> = Readonly<{ [key: string]: T }>;
+export type Pairs<T, U> = ReadonlyArray<[T, U]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,110 +1,12 @@
-export interface IStringKeys {
-  [key: string]: any;
-}
-
-export type Dict<T> = Readonly<{ [key: string]: T }>;
-
-export function SimpleRecord<T extends IStringKeys>(
-  defaults: T
-): (input?: Partial<T>) => Readonly<T> {
-  return function record(input?: Partial<T>) {
-    if (input) {
-      return {
-        ...(defaults as any),
-        ...(input as any),
-      };
-    }
-    return defaults;
-  };
-}
-
-export function RecordWithConstructor<
-  T extends IStringKeys,
-  U extends IStringKeys
->(
-  defaults: T,
-  constructorFunction: (input: T) => Readonly<U>
-): (input?: Partial<T>) => Readonly<U> {
-  const innerRecord = SimpleRecord<T>(defaults);
-
-  return function record(input?: Partial<T>): U {
-    const preTransform = innerRecord(input);
-    return constructorFunction(preTransform);
-  };
-}
-
-export function recordOrUndefined<T extends IStringKeys, U extends IStringKeys>(
-  data: T | undefined,
-  constructorFunction: (input: T) => U
-): U | undefined {
-  if (data !== undefined) {
-    return constructorFunction(data);
-  }
-  return undefined;
-}
-
-export function recordOrNull<T extends IStringKeys, U extends IStringKeys>(
-  data: T | null,
-  constructorFunction: (input: T) => U
-): U | null {
-  if (data !== null) {
-    return constructorFunction(data);
-  }
-  return null;
-}
-
-export function recordOrId<T extends IStringKeys, U extends IStringKeys>(
-  data: T | string,
-  constructorFunction: (input: T) => U
-): U | string {
-  if (typeof data !== 'string') {
-    return constructorFunction(data as T);
-  }
-  return data as string;
-}
-
-export function recordArray<T extends IStringKeys, U extends IStringKeys>(
-  data: ReadonlyArray<T> | undefined,
-  ctor: (item: T) => U
-): ReadonlyArray<U> {
-  if (!data) {
-    return [];
-  }
-  return data.map(item => ctor(item));
-}
-
-export function recordOrIdArray<T extends IStringKeys, U extends IStringKeys>(
-  data: ReadonlyArray<Partial<T>> | ReadonlyArray<string>,
-  constructor: (item: Partial<T>) => U
-): ReadonlyArray<U> | ReadonlyArray<string> {
-  const first = data[0];
-
-  if (typeof first === 'string') {
-    return data as ReadonlyArray<string>;
-  } else {
-    return (data as ReadonlyArray<Partial<T>>).map(item => constructor(item));
-  }
-}
-
-export function narrowToRecord<T>(input: T | string): T {
-  if (typeof input === 'string') {
-    throw new Error(
-      `Tried to narrow an ID into a Record - ${typeof input} ${input}`
-    );
-  }
-  return input as T;
-}
-
-export function narrowToRecordArray<T>(
-  input: ReadonlyArray<T> | ReadonlyArray<string>
-): ReadonlyArray<T> {
-  if (input.length === 0) {
-    return [];
-  }
-  const first = input[0];
-
-  if (typeof first === 'string') {
-    throw new Error('Tried to narrow an Array of IDs');
-  }
-  return input as ReadonlyArray<T>;
-}
+export { Dict, ObjectKeys, Pairs } from './core';
+export { Proplist, proplistToDict, dictToProplist } from './proplists';
+export { SimpleRecord, RecordWithConstructor } from './records';
+export {
+  recordOrUndefined,
+  recordOrNull,
+  recordOrId,
+  recordArray,
+  recordOrIdArray,
+  narrowToRecord,
+  narrowToRecordArray,
+} from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { Dict, ObjectKeys, Pairs } from './core';
-export { Proplist, proplistToDict, dictToProplist } from './proplists';
+export {
+  Proplist,
+  proplistGetFirst,
+  proplistToDict,
+  dictToProplist,
+} from './proplists';
 export { SimpleRecord, RecordWithConstructor } from './records';
 export {
   recordOrUndefined,

--- a/src/proplists.ts
+++ b/src/proplists.ts
@@ -13,7 +13,19 @@ export function proplistToDict<T>(proplist: Proplist<T>): Dict<T> {
 
 export function dictToProplist<T>(dict: Dict<T>): Proplist<T> {
   return Object.keys(dict).reduce(
-    (memo, key): Proplist<T> => [...memo, [key, dict[key]]],
+    (memo: Proplist<T>, key): Proplist<T> => [...memo, [key, dict[key]]],
     []
   );
+}
+
+export function proplistGetFirst<T>(
+  proplist: Proplist<T>,
+  index: string
+): T | undefined {
+  for (const i in proplist) {
+    if (proplist[i][0] === index) {
+      return proplist[i][1];
+    }
+  }
+  return undefined;
 }

--- a/src/proplists.ts
+++ b/src/proplists.ts
@@ -1,0 +1,19 @@
+import { Dict, Pairs } from './core';
+
+export type Proplist<T> = Pairs<string, T>;
+
+export function proplistToDict<T>(proplist: Proplist<T>): Dict<T> {
+  return proplist.reduce((memo, [key, value]) => {
+    return {
+      ...memo,
+      [key]: value,
+    };
+  }, {});
+}
+
+export function dictToProplist<T>(dict: Dict<T>): Proplist<T> {
+  return Object.keys(dict).reduce(
+    (memo, key): Proplist<T> => [...memo, [key, dict[key]]],
+    []
+  );
+}

--- a/src/proplists.ts
+++ b/src/proplists.ts
@@ -5,8 +5,8 @@ export type Proplist<T> = Pairs<string, T>;
 export function proplistToDict<T>(proplist: Proplist<T>): Dict<T> {
   return proplist.reduce((memo, [key, value]) => {
     return {
-      ...memo,
       [key]: value,
+      ...memo,
     };
   }, {});
 }

--- a/src/records.ts
+++ b/src/records.ts
@@ -1,0 +1,30 @@
+import { ObjectKeys } from './core';
+
+export function SimpleRecord<T extends ObjectKeys>(
+  defaults: T
+): (input?: Partial<T>) => Readonly<T> {
+  return function record(input?: Partial<T>) {
+    if (input) {
+      return {
+        ...(defaults as any),
+        ...(input as any),
+      };
+    }
+    return defaults;
+  };
+}
+
+export function RecordWithConstructor<
+  T extends ObjectKeys,
+  U extends ObjectKeys
+>(
+  defaults: T,
+  constructorFunction: (input: T) => Readonly<U>
+): (input?: Partial<T>) => Readonly<U> {
+  const innerRecord = SimpleRecord<T>(defaults);
+
+  return function record(input?: Partial<T>): U {
+    const preTransform = innerRecord(input);
+    return constructorFunction(preTransform);
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,77 @@
+import { ObjectKeys } from './core';
+
+export function recordOrUndefined<T extends ObjectKeys, U extends ObjectKeys>(
+  data: T | undefined,
+  constructorFunction: (input: T) => U
+): U | undefined {
+  if (data !== undefined) {
+    return constructorFunction(data);
+  }
+  return undefined;
+}
+
+export function recordOrNull<T extends ObjectKeys, U extends ObjectKeys>(
+  data: T | null,
+  constructorFunction: (input: T) => U
+): U | null {
+  if (data !== null) {
+    return constructorFunction(data);
+  }
+  return null;
+}
+
+export function recordOrId<T extends ObjectKeys, U extends ObjectKeys>(
+  data: T | string,
+  constructorFunction: (input: T) => U
+): U | string {
+  if (typeof data !== 'string') {
+    return constructorFunction(data as T);
+  }
+  return data as string;
+}
+
+export function recordArray<T extends ObjectKeys, U extends ObjectKeys>(
+  data: ReadonlyArray<T> | undefined,
+  ctor: (item: T) => U
+): ReadonlyArray<U> {
+  if (!data) {
+    return [];
+  }
+  return data.map(item => ctor(item));
+}
+
+export function recordOrIdArray<T extends ObjectKeys, U extends ObjectKeys>(
+  data: ReadonlyArray<Partial<T>> | ReadonlyArray<string>,
+  constructor: (item: Partial<T>) => U
+): ReadonlyArray<U> | ReadonlyArray<string> {
+  const first = data[0];
+
+  if (typeof first === 'string') {
+    return data as ReadonlyArray<string>;
+  } else {
+    return (data as ReadonlyArray<Partial<T>>).map(item => constructor(item));
+  }
+}
+
+export function narrowToRecord<T>(input: T | string): T {
+  if (typeof input === 'string') {
+    throw new Error(
+      `Tried to narrow an ID into a Record - ${typeof input} ${input}`
+    );
+  }
+  return input as T;
+}
+
+export function narrowToRecordArray<T>(
+  input: ReadonlyArray<T> | ReadonlyArray<string>
+): ReadonlyArray<T> {
+  if (input.length === 0) {
+    return [];
+  }
+  const first = input[0];
+
+  if (typeof first === 'string') {
+    throw new Error('Tried to narrow an Array of IDs');
+  }
+  return input as ReadonlyArray<T>;
+}

--- a/tests/proplist.ts
+++ b/tests/proplist.ts
@@ -25,7 +25,14 @@ describe('proplists', () => {
       const result = proplistToDict(myProplist);
       expect(result).toEqual({ a: 1, b: 2 });
     });
+
+    it('should favour the first instance of a value when duplicates exist', () => {
+      const myProplist: Proplist<number> = [['a', 1], ['b', 2], ['b', 3]];
+      const result = proplistToDict(myProplist);
+      expect(result).toEqual({ a: 1, b: 2 });
+    });
   });
+
   describe('dictToProplist', () => {
     it('should convert a dictionary into a proplist', () => {
       const myDict: Dict<number> = { a: 1, b: 2 };

--- a/tests/proplist.ts
+++ b/tests/proplist.ts
@@ -1,0 +1,38 @@
+import {
+  Dict,
+  dictToProplist,
+  Proplist,
+  proplistGetFirst,
+  proplistToDict,
+} from '../src/';
+
+describe('proplists', () => {
+  describe('proplistGetFirst', () => {
+    const myProplist: Proplist<number> = [['a', 1], ['b', 2], ['b', 3]];
+
+    it('should get the first instance of a key', () => {
+      expect(proplistGetFirst(myProplist, 'b')).toBe(2);
+    });
+
+    it('should handle the key not existing', () => {
+      expect(proplistGetFirst(myProplist, 'c')).toBe(undefined);
+    });
+  });
+
+  describe('proplistToDict', () => {
+    it('should convert a proplist into a dictionary', () => {
+      const myProplist: Proplist<number> = [['a', 1], ['b', 2]];
+      const result = proplistToDict(myProplist);
+      expect(result).toEqual({ a: 1, b: 2 });
+    });
+  });
+  describe('dictToProplist', () => {
+    it('should convert a dictionary into a proplist', () => {
+      const myDict: Dict<number> = { a: 1, b: 2 };
+      const result = dictToProplist(myDict);
+      expect(result.length).toBe(2);
+      expect(proplistGetFirst(result, 'a')).toBe(1);
+      expect(proplistGetFirst(result, 'b')).toBe(2);
+    });
+  });
+});

--- a/tests/records.ts
+++ b/tests/records.ts
@@ -1,0 +1,79 @@
+import { RecordWithConstructor, SimpleRecord } from '../src/';
+
+type ISimpleInterface = Readonly<{
+  a: number;
+  b: string;
+}>;
+
+const MySimpleRecord = SimpleRecord<ISimpleInterface>({
+  a: 5,
+  b: '--',
+});
+
+describe('SimpleRecord', () => {
+  it('should provide defaults to an empty constructor', () => {
+    const instance = MySimpleRecord();
+    expect(instance.a).toBe(5);
+    expect(instance.b).toBe('--');
+  });
+
+  it('should mix valid data in over defaults', () => {
+    const instance = MySimpleRecord({
+      b: 'llama',
+    });
+    expect(instance.a).toBe(5);
+    expect(instance.b).toBe('llama');
+  });
+});
+
+interface IComplexInterfaceShared {
+  first: string;
+}
+
+type IComplexInterfaceInput = Readonly<
+  IComplexInterfaceShared & {
+    second: Partial<ISimpleInterface>;
+  }
+>;
+type IComplexInterface = Readonly<
+  IComplexInterfaceShared & {
+    second: ISimpleInterface;
+  }
+>;
+
+const MyComplexRecord = RecordWithConstructor<
+  IComplexInterfaceInput,
+  IComplexInterface
+>(
+  {
+    first: 'first',
+    second: {},
+  },
+  input => {
+    return {
+      ...input,
+      second: MySimpleRecord(input.second),
+    };
+  }
+);
+
+describe('RecordWithConstructor', () => {
+  it('should deeply construct my items', () => {
+    const instance = MyComplexRecord();
+    expect(instance.first).toBe('first');
+    expect(instance.second.a).toBe(5);
+    expect(instance.second.b).toBe('--');
+  });
+
+  it('should provide correctly merged defaults', () => {
+    const instance = MyComplexRecord({
+      first: 'a',
+      second: {
+        a: 10,
+      },
+    });
+    expect(instance.first).toBe('a');
+    expect(instance.second.a).toBe(10);
+    expect(instance.second.b).toBe('--');
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,7 +6,6 @@ import {
   recordOrIdArray,
   recordOrNull,
   recordOrUndefined,
-  RecordWithConstructor,
   SimpleRecord,
 } from '../src/';
 
@@ -18,73 +17,6 @@ type ISimpleInterface = Readonly<{
 const MySimpleRecord = SimpleRecord<ISimpleInterface>({
   a: 5,
   b: '--',
-});
-
-describe('SimpleRecord', () => {
-  it('should provide defaults to an empty constructor', () => {
-    const instance = MySimpleRecord();
-    expect(instance.a).toBe(5);
-    expect(instance.b).toBe('--');
-  });
-
-  it('should mix valid data in over defaults', () => {
-    const instance = MySimpleRecord({
-      b: 'llama',
-    });
-    expect(instance.a).toBe(5);
-    expect(instance.b).toBe('llama');
-  });
-});
-
-interface IComplexInterfaceShared {
-  first: string;
-}
-type IComplexInterfaceInput = Readonly<
-  IComplexInterfaceShared & {
-    second: Partial<ISimpleInterface>;
-  }
->;
-type IComplexInterface = Readonly<
-  IComplexInterfaceShared & {
-    second: ISimpleInterface;
-  }
->;
-
-const MyComplexRecord = RecordWithConstructor<
-  IComplexInterfaceInput,
-  IComplexInterface
->(
-  {
-    first: 'first',
-    second: {},
-  },
-  input => {
-    return {
-      ...input,
-      second: MySimpleRecord(input.second),
-    };
-  }
-);
-
-describe('RecordWithConstructor', () => {
-  it('should deeply construct my items', () => {
-    const instance = MyComplexRecord();
-    expect(instance.first).toBe('first');
-    expect(instance.second.a).toBe(5);
-    expect(instance.second.b).toBe('--');
-  });
-
-  it('should provide correctly merged defaults', () => {
-    const instance = MyComplexRecord({
-      first: 'a',
-      second: {
-        a: 10,
-      },
-    });
-    expect(instance.first).toBe('a');
-    expect(instance.second.a).toBe(10);
-    expect(instance.second.b).toBe('--');
-  });
 });
 
 describe('recordOrUndefined', () => {
@@ -129,6 +61,11 @@ describe('recordArray', () => {
     expect(items[0].a).toBe(5);
     expect(items[1].a).toBe(5);
   });
+
+  it('should handle empty inputs', () => {
+    const items = recordArray(undefined, MySimpleRecord);
+    expect(items).toEqual([]);
+  });
 });
 
 describe('recordOrIdArray', () => {
@@ -168,5 +105,10 @@ describe('narrowToRecordArray', () => {
     expect(() => {
       narrowToRecordArray(['5', '6']);
     }).toThrow();
+  });
+
+  it('should handle empty arrays', () => {
+    const items = narrowToRecordArray([]);
+    expect(items).toEqual([]);
   });
 });


### PR DESCRIPTION
This PR splits up the code into easier-to-manage files, and also adds support for Proplists.

A proplist is an ordered list of key-value pairs, and can be converted back and forth between Dicts with ease.  However, a Proplist has the additional property of allowing duplicate keys.

Proplists are a natural data type to represent URL GET params, which are both ordered and allow duplicates.  They are also useful for allowing for easy iteration over a dictionary's values.