### PR TITLE
Update README to use OrderedDict instead of OrderedMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,22 +113,22 @@ const myOtherProplist = dictToProplist({a: 1, b: 2});
 There is also a MutableProplist type, for times when you need mutability.
 
 
-### OrderedMap
+### OrderedDict
 
-An OrderedMap is an object that combines the guaranteed order characteristics of an Array with the indexability of a Dict.  They can be created from Dicts (although, bare in mind Dicts are not ordered so you will need to provide a sort, otherwise it will sort alphabetically by key), and from Proplists (which will cause duplicate values to be dropped).  They can also be created from scratch.  It is not recommended as it is error-prone, but you can also initialize them with a list of keys, and a dictionary of items.
+An OrderedDict is an object that combines the guaranteed order characteristics of an Array with the indexability of a Dict.  They can be created from Dicts (although, bare in mind Dicts are not ordered so you will need to provide a sort, otherwise it will sort alphabetically by key), and from Proplists (which will cause duplicate values to be dropped).  They can also be created from scratch.  It is not recommended as it is error-prone, but you can also initialize them with a list of keys, and a dictionary of items.
 
 ```typescript
-const orderedMap1 = new OrderedMap<number>();
-const orderedMap2 = OrderedMap.fromDict({'a': 1, 'b': 2, 'c': 3});
-const orderedMap3 = OrderedMap.fromProplist([['a', 1], ['b', 2], ['c', 3]]);
+const orderedDict1 = new OrderedDict<number>();
+const orderedDict2 = OrderedDict.fromDict({'a': 1, 'b': 2, 'c': 3});
+const orderedDict3 = OrderedDict.fromProplist([['a', 1], ['b', 2], ['c', 3]]);
 
 // Don't do this unless you're really sure
-const handInitialized = new OrderedMap<number>(['a', 'b', 'c'], {'a': 1, 'b': 2, 'c': 3});
+const handInitialized = new OrderedDict<number>(['a', 'b', 'c'], {'a': 1, 'b': 2, 'c': 3});
 
-const orderedMapUpdated = orderedMap2.set('b', 5);
-const valueOfB = orderedMapUpdated.get('b');
+const orderedDictUpdated = orderedDict2.set('b', 5);
+const valueOfB = orderedDictUpdated.get('b');
 
-const orderedMapMerged = orderedMap2.merge(orderedMap3, ([leftKey, leftValue], [rightKey, rightValue]) => leftValue - rightValue);
+const orderedDictMerged = orderedDict2.merge(orderedDict3, ([leftKey, leftValue], [rightKey, rightValue]) => leftValue - rightValue);
 ```
 
 Additional Array-like methods are provided to match the behaviour of native Arrays.


### PR DESCRIPTION
Rename OrderedMap to OrderedDict in README to match Object name.