### PR TITLE
Renamed all method to every in OrderedDict

### DIFF
--- a/src/ordered-dict.ts
+++ b/src/ordered-dict.ts
@@ -158,7 +158,7 @@ export class OrderedDict<T> {
     return false;
   }
 
-  public all(
+  public every(
     callback: (value: T, key: string, index: number) => boolean
   ): boolean {
     let index = 0;

--- a/tests/ordered-dict.ts
+++ b/tests/ordered-dict.ts
@@ -256,15 +256,15 @@ describe('OrderedDict', () => {
       });
     });
 
-    describe('all', () => {
+    describe('every', () => {
       it('should return true if we have all matches', () => {
         const od = OrderedDict.fromDict(inputDict);
-        expect(od.all(item => item > 0)).toBe(true);
+        expect(od.every(item => item > 0)).toBe(true);
       });
 
       it("should return false if we don't have all matches", () => {
         const od = OrderedDict.fromDict(inputDict);
-        expect(od.all(item => item > 1)).toBe(false);
+        expect(od.every(item => item > 1)).toBe(false);
       });
     });
 


### PR DESCRIPTION
Renamed `all()` method to `every()` in OrderedDict to better coinside with javascript array prototype naming scheme